### PR TITLE
🔧 Fix Render Deployment: Correct Service Type for Static Site

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,8 +13,9 @@ services:
     healthCheckPath: /api/health
     
   # Frontend static site
-  - type: static
+  - type: web
     name: cheera-udaykiran
+    runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist
     plan: free


### PR DESCRIPTION
## 🚨 Critical Fix for Render Deployment

This PR fixes the **"unknown type static"** error encountered during Render deployment.

### 🐛 Problem

When deploying to Render using the `render.yaml` file, the deployment failed with:
```
unknown type "static"
```

### ✅ Solution

Updated the `render.yaml` configuration to use the correct Render service types:

**Before (❌ Incorrect):**
```yaml
- type: static
  name: cheera-udaykiran
  buildCommand: npm install && npm run build
  staticPublishPath: ./dist
```

**After (✅ Correct):**
```yaml
- type: web
  runtime: static
  name: cheera-udaykiran
  buildCommand: npm install && npm run build
  staticPublishPath: ./dist
```

### 📋 Changes Made

- **render.yaml**: Changed `type: static` to `type: web` with `runtime: static`
- This follows Render's official documentation for static site deployment

### 🚀 Impact

✅ **Render deployment will now work correctly**
✅ **No more "unknown type static" error**
✅ **Both backend and frontend services properly configured**

### 🧪 Testing

After merging this PR:
1. The render.yaml file should be accepted by Render
2. Both services (backend API and frontend static site) should deploy successfully
3. You can proceed with setting environment variables in Render dashboard

### 📚 Related

This fix is essential for the deployment improvements made in the previous PR that addressed security vulnerabilities and prepared the portfolio for production deployment.

---

**⚡ This is a critical fix that unblocks Render deployment. Ready for immediate merge.**