### PR TITLE
🔧 Fix Render Plan Error: Remove Plan Specification for Static Site

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,7 +18,6 @@ services:
     runtime: static
     buildCommand: npm install && npm run build
     staticPublishPath: ./dist
-    plan: free
     pullRequestPreviewsEnabled: true
     headers:
       - path: /*


### PR DESCRIPTION
## 🚨 Critical Fix for Render Plan Error

This PR fixes the **"no such plan free for service type web"** error encountered during Render deployment.

### 🐛 Problem

When deploying to Render using the `render.yaml` file, the deployment failed with:
```
services[1].plan
    no such plan free for service type web
```

### ✅ Solution

Removed the `plan: free` specification from the static site service because:
- **Static sites on Render are free by default**
- **They don't use plan designations like Node.js web services**
- **Only the backend API service needs the `plan: free` specification**

### 📋 Changes Made

**Before (❌ Incorrect):**
```yaml
- type: web
  name: cheera-udaykiran
  runtime: static
  buildCommand: npm install && npm run build
  staticPublishPath: ./dist
  plan: free  # ← This caused the error
```

**After (✅ Correct):**
```yaml
- type: web
  name: cheera-udaykiran
  runtime: static
  buildCommand: npm install && npm run build
  staticPublishPath: ./dist
  # No plan specification needed for static sites
```

### 🚀 Impact

✅ **Render deployment will now work correctly**
✅ **No more "no such plan free" error for static sites**
✅ **Both backend (with plan: free) and frontend (no plan) properly configured**

### 🧪 Testing

After merging this PR:
1. The render.yaml file should be accepted by Render
2. Both services should deploy successfully:
   - Backend API: Uses `plan: free` (correct for Node.js web service)
   - Frontend: No plan needed (free by default for static sites)
3. You can proceed with setting environment variables in Render dashboard

### 📚 Related

This fix addresses the specific plan error that occurred after the previous deployment configuration fixes.

---

**⚡ This is a critical fix that unblocks Render deployment. Ready for immediate merge.**